### PR TITLE
fix: correct the repository urls in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+    "url": "https://github.com/scorelab/Webiu"
   },
   "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
+    "url": "https://github.com/scorelab/Webiu/issues"
   }
 }


### PR DESCRIPTION
### Changes

The *urls* in *package.json* at the **repository root** pointed to the [incorrect repository](https://github.com/gatsbyjs/gatsby-starter-default).

This fixes the the urls with [the correct urls](https://github.com/scorelab/Webiu)