### PR TITLE
created a reusable component to embed facebook and twitter in websites

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {ProjectsListSearch} from './src/components/ProjectsListSearch';
+export {ContributersList} from './src/components/ContributersList';
+export {SocialSiteEmbed} from './src/components/SocialSiteEmbed';

--- a/index.js
+++ b/index.js
@@ -20,6 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-export {ProjectsListSearch} from './src/components/ProjectsListSearch';
-export {ContributersList} from './src/components/ContributersList';
 export {SocialSiteEmbed} from './src/components/SocialSiteEmbed';

--- a/src/components/SocialSiteEmbed/index.js
+++ b/src/components/SocialSiteEmbed/index.js
@@ -1,0 +1,39 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col, Form} from 'react-bootstrap'
+
+export const SocialSiteEmbed = ({facebookProfile, twitterProfile}) => {
+  const facebookApi = `https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2F
+                       ${facebookProfile}
+                       %2F&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId`;
+  const twitterApi = `https://twitter.com/${twitterProfile}?ref_src=twsrc%5Etfw`;
+  return (
+    <div className="embed-component">
+      <Container>
+        <Row>
+          <Col md={6}>
+            <div>
+              <iframe src={facebookApi}
+                      width="340" height="500" style={{border:"none", overflow: "hidden"}} scrolling="no" frameborder="0"
+                      allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
+            </div>
+          </Col>
+          <Col md={6}>
+
+            <a class="twitter-timeline" width="340" height="500" href={twitterApi}
+               style={{border:"none", overflow: "hidden"}}>
+            Tweets by {twitterProfile}</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  )
+}
+
+
+SocialSiteEmbed.propTypes = {
+  facebookProfile: PropTypes.string,
+  twitterProfile: PropTypes.string,
+}

--- a/src/components/SocialSiteEmbed/index.js
+++ b/src/components/SocialSiteEmbed/index.js
@@ -2,38 +2,52 @@ import React from "react"
 import PropTypes from "prop-types"
 import "./style.sass"
 import {Container, Row, Col, Form} from 'react-bootstrap'
+import {Helmet} from "react-helmet"
 
-export const SocialSiteEmbed = ({facebookProfile, twitterProfile}) => {
-  const facebookApi = `https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2F
+export const SocialSiteEmbed = ({facebookProfile, twitterProfile, header}) => {
+  const facebookEmbedLink = `https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2F
                        ${facebookProfile}
                        %2F&tabs=timeline&width=340&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId`;
-  const twitterApi = `https://twitter.com/${twitterProfile}?ref_src=twsrc%5Etfw`;
+
+  const twitterEmbedLink = `https://twitter.com/${twitterProfile}?ref_src=twsrc%5Etfw`;
+
   return (
     <div className="embed-component">
+      { header ?
+        <div className="header-component">
+         <h3>{header}</h3>
+        </div>
+       : null }
+       <div className={header? "header-component" : null}>
       <Container>
         <Row>
           <Col md={6}>
             <div>
-              <iframe src={facebookApi}
+              <iframe src={facebookEmbedLink}
                       width="340" height="500" style={{border:"none", overflow: "hidden"}} scrolling="no" frameborder="0"
                       allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
             </div>
           </Col>
           <Col md={6}>
-
-            <a class="twitter-timeline" width="340" height="500" href={twitterApi}
+            <div className="">
+            <a class="twitter-timeline twitter-feed" width="340" height="500" href={twitterEmbedLink}
                style={{border:"none", overflow: "hidden"}}>
-            Tweets by {twitterProfile}</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            Tweets by {twitterProfile}</a>
+            </div>
 
+            <Helmet>
+                <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </Helmet>
           </Col>
         </Row>
       </Container>
+      </div>
     </div>
   )
 }
 
-
 SocialSiteEmbed.propTypes = {
   facebookProfile: PropTypes.string,
   twitterProfile: PropTypes.string,
+  header: PropTypes.string
 }

--- a/src/components/SocialSiteEmbed/style.sass
+++ b/src/components/SocialSiteEmbed/style.sass
@@ -1,0 +1,21 @@
+@import '../../styles/variables-example.sass';
+
+.embed-component {
+  padding: 30px;
+  background-color: #fff;
+  text-align: center;
+  padding-bottom: 120px;
+
+  .col-md-6 {
+    @media #{$md-and-less} {
+      padding: 0px 20px !important;
+    }
+    @media #{$xs-and-less} {
+      padding: 0px 10px !important;
+    }
+    padding: 0px 40px !important;
+  }
+}
+.twitter-feed {
+  border-style: solid;
+}

--- a/src/components/SocialSiteEmbed/style.sass
+++ b/src/components/SocialSiteEmbed/style.sass
@@ -1,21 +1,18 @@
-@import '../../styles/variables-example.sass';
+@import '../../styles/variables.sass'
 
-.embed-component {
-  padding: 30px;
-  background-color: #fff;
-  text-align: center;
-  padding-bottom: 120px;
-
-  .col-md-6 {
-    @media #{$md-and-less} {
-      padding: 0px 20px !important;
-    }
-    @media #{$xs-and-less} {
-      padding: 0px 10px !important;
-    }
-    padding: 0px 40px !important;
-  }
-}
-.twitter-feed {
-  border-style: solid;
-}
+.embed-component
+  padding-top: 0px
+  background-color: #fff
+  text-align: center
+  padding-bottom: 120px
+  .col-md-6
+    @media #{$md-and-less}
+      padding: 0px 20px !important
+    @media #{$xs-and-less}
+      padding: 0px 10px !important
+    padding: 0px 40px !important
+  .header-component
+    background-image: url("../../../static/images/dots.png")
+    padding: 35px
+    background-color: #f3faff
+    text-align: center


### PR DESCRIPTION
This PR fixes #32 
Created a reusable component to embed Facebook and Twitter mark-ups in the website where the profile name has to be passed as a prop to the component and it would render the desired result. This is also open to being extended to include LinkedIn and youtube mark-ups as well. 
It uses Facebook and Twitter APIs to render data.
![twitter-embed](https://user-images.githubusercontent.com/62200066/107755501-e57a4300-6d48-11eb-9aed-c0f2f221ede0.png)

