### PR TITLE
create a reusable FAQ component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {FaqComponent} from './src/components/FaqComponent';

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.12.0",
+    "react-faq-component": "^1.3.0",
     "react-helmet": "^5.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.12.0",
-    "react-faq-component": "^1.3.0",
     "react-helmet": "^5.2.1"
   },
   "devDependencies": {

--- a/src/components/FaqComponent/Accordion.js
+++ b/src/components/FaqComponent/Accordion.js
@@ -1,0 +1,43 @@
+import React, { useState, useRef } from "react";
+import Chevron from "./Chevron";
+
+import "./style.sass";
+
+function Accordion(props) {
+  const [setActive, setActiveState] = useState("");
+  const [setHeight, setHeightState] = useState("0px");
+  const [setRotate, setRotateState] = useState("accordion__icon");
+
+  const content = useRef(null);
+
+  function toggleAccordion() {
+    setActiveState(setActive === "" ? "active" : "");
+    setHeightState(
+      setActive === "active" ? "0px" : `${content.current.scrollHeight}px`
+    );
+    setRotateState(
+      setActive === "active" ? "accordion__icon" : "accordion__icon rotate"
+    );
+  }
+
+  return (
+    <div className="accordion__section">
+      <button className={`accordion ${setActive}`} onClick={toggleAccordion}>
+        <p className="accordion__title">{props.title}</p>
+        <Chevron className={`${setRotate}`} width={10} fill={"#777"} />
+      </button>
+      <div
+        ref={content}
+        style={{ maxHeight: `${setHeight}` }}
+        className="accordion__content"
+      >
+        <div
+          className="accordion__text"
+          dangerouslySetInnerHTML={{ __html: props.content }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Accordion;

--- a/src/components/FaqComponent/Chevron.js
+++ b/src/components/FaqComponent/Chevron.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+function Chevron(props) {
+  return (
+    <svg
+      className={props.className}
+      height={props.height}
+      width={props.width}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 320 512"
+    >
+      <path
+        fill={props.fill}
+        d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
+      />
+    </svg>
+  );
+}
+
+export default Chevron;

--- a/src/components/FaqComponent/index.js
+++ b/src/components/FaqComponent/index.js
@@ -1,0 +1,23 @@
+import React from "react"
+import PropTypes from "prop-types"
+import Faq from 'react-faq-component';
+import {Container, Row, Col} from 'react-bootstrap'
+import "./style.sass";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+
+export const FaqComponent = ({data}) => {
+
+  return (
+    <div>
+      <div className="header-component">
+        <h3><FontAwesomeIcon className="icon" icon={faQuestionCircle} />{data.title}</h3>
+      </div>
+      <Container>
+      <div>
+        <Faq data={data}/>
+      </div>
+      </Container>
+    </div>
+  )
+}

--- a/src/components/FaqComponent/index.js
+++ b/src/components/FaqComponent/index.js
@@ -1,23 +1,34 @@
-import React from "react"
+import React from "react";
+import ReactDOM from "react-dom";
 import PropTypes from "prop-types"
-import Faq from 'react-faq-component';
+import Accordion from "./Accordion";
 import {Container, Row, Col} from 'react-bootstrap'
-import "./style.sass";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { faQuestion } from '@fortawesome/free-solid-svg-icons';
 
-export const FaqComponent = ({data}) => {
+import "./style.sass";
 
+export const FaqComponent = ({data, header}) => {
   return (
     <div>
+    { header ?
       <div className="header-component">
-        <h3><FontAwesomeIcon className="icon" icon={faQuestionCircle} />{data.title}</h3>
+       <h3>{header} <FontAwesomeIcon className="icon" icon={faQuestion} /></h3>
       </div>
-      <Container>
-      <div>
-        <Faq data={data}/>
-      </div>
-      </Container>
+     : null }
+    <Container className="faq-container">
+      {data.length >=1 ? data.map(faq => (
+        <Accordion
+          title={faq.title}
+          content={faq.content}
+        />
+      )) : null}
+    </Container>
     </div>
-  )
+  );
+}
+
+Faq.propTypes = {
+  data: PropTypes.array,
+  heading: PropTypes.string
 }

--- a/src/components/FaqComponent/style.sass
+++ b/src/components/FaqComponent/style.sass
@@ -1,34 +1,46 @@
-@import '../../styles/variables-example.sass';
+@import '../../styles/variables.sass'
 
-.header-component {
-  background-image: url("../../../static/images/dots.png");
-  padding: 35px;
-  background-color: #f3faff;
-  text-align: center;
-  margin-bottom: 40px;
-}
-.icon {
-  color: green;
-  font-size: 30px;
-  margin-right: 10px;
-}
-.faq-row-wrapper {
-
-    .faq-title {
-      display: none;
-    }
-
-    .faq-body {
-        .faq-row {
-            .row-title {
-              color: green;
-            }
-            .row-content {
-                .row-content-text {
-                  color: black;
-                  font-size: 15px;
-                }
-            }
-        }
-    }
-}
+.accordion__section
+  display: flex
+  flex-direction: column
+.accordion
+  background-color: #eee
+  color: #444
+  cursor: pointer
+  padding: 18px
+  display: flex
+  align-items: center
+  border: none
+  outline: none
+  transition: background-color 0.6s ease
+.accordion:hover,
+.active
+  background-color: #ccc
+.accordion__title
+  font-family: "Open Sans", sans-serif
+  font-weight: 600
+  font-size: 14px
+  text-align: left
+.accordion__icon
+  margin-left: auto
+  transition: transform 0.6s ease
+.rotate
+  transform: rotate(90deg)
+.accordion__content
+  background-color: white
+  overflow: auto
+  transition: max-height 0.6s ease
+.accordion__text
+  font-family: "Open Sans", sans-serif
+  font-weight: 400
+  font-size: 14px
+  padding: 18px
+.header-component
+  background-image: url("../../../static/images/dots.png")
+  padding: 35px
+  background-color: #f3faff
+  text-align: center
+.icon
+  color: green
+.faq-container
+  margin: 5rem auto

--- a/src/components/FaqComponent/style.sass
+++ b/src/components/FaqComponent/style.sass
@@ -1,0 +1,34 @@
+@import '../../styles/variables-example.sass';
+
+.header-component {
+  background-image: url("../../../static/images/dots.png");
+  padding: 35px;
+  background-color: #f3faff;
+  text-align: center;
+  margin-bottom: 40px;
+}
+.icon {
+  color: green;
+  font-size: 30px;
+  margin-right: 10px;
+}
+.faq-row-wrapper {
+
+    .faq-title {
+      display: none;
+    }
+
+    .faq-body {
+        .faq-row {
+            .row-title {
+              color: green;
+            }
+            .row-content {
+                .row-content-text {
+                  color: black;
+                  font-size: 15px;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves #35 
Created a reusable and highly customizable FAQ component which would speed up getting a website up and running. The data to be displayed needs to be passed as a prop to the component like this - 

![faq-code](https://user-images.githubusercontent.com/62200066/107853727-94984680-6e3d-11eb-8de4-1faf32e820cc.png)

The stylesheet has been updated to do custom styling if required, the component formally looks like this, with a lot of flexibility possible

![faq](https://user-images.githubusercontent.com/62200066/107853840-36b82e80-6e3e-11eb-8faf-8c0bab67f8a6.png)
