### PR TITLE
Created a reusable slick-carousel component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {SlickCarousel} from './src/components/SlickCarousel';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.12.0",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "react-slick": "^0.28.0",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "prettier": "^1.19.1"

--- a/src/components/SlickCarousel/index.js
+++ b/src/components/SlickCarousel/index.js
@@ -1,0 +1,71 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container} from 'react-bootstrap'
+import Slider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
+export const SlickCarousel = ({header, data}) => {
+  var settings = {
+    className: "slides",
+    infinite: true,
+    speed: 2000,
+    centerMode: true,
+    slidesToShow: 3,
+    slidesToScroll: 1,
+    autoplay: true,
+    arrows: true,
+    responsive: [
+      {
+        breakpoint: 1024,
+        settings: {
+          slidesToShow: 3,
+          slidesToScroll: 3,
+          infinite: true,
+          dots: true
+        }
+      },
+      {
+        breakpoint: 800,
+        settings: {
+          slidesToShow: 2,
+          slidesToScroll: 2,
+          initialSlide: 2
+        }
+      },
+      {
+        breakpoint: 480,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1
+        }
+      }
+    ]
+  };
+
+  return (
+    <div>
+    {header ? <div className="header-component">
+     <h3>{header}</h3>
+    </div> : null}
+    <Container>
+    {data.length >= 1 ? <Slider {...settings}>
+      {data.map(data => (
+        <a href={data.link}>
+         <div className="slick-div">
+          <h5>{data.title}</h5>
+          <img src={data.image} />
+         </div>
+        </a>
+      ))}
+    </Slider> : null}
+    </Container>
+    </div>
+  )
+}
+
+SlickCarousel.propTypes = {
+   header: PropTypes.string,
+   data: PropTypes.array
+}

--- a/src/components/SlickCarousel/style.sass
+++ b/src/components/SlickCarousel/style.sass
@@ -1,0 +1,50 @@
+@import '../../styles/variables-example.sass';
+
+.slick-div {
+  img {
+    width: 100px;
+    height: 100px;
+    margin: auto;
+  }
+  border-style: solid;
+  text-align: center;
+}
+.slides {
+  .slick-prev {
+    left: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+  .slick-prev:hover {
+    left: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+  .slick-prev:focus {
+    left: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+  .slick-next {
+    right: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+  .slick-next:hover {
+    right: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+  .slick-next:focus {
+    right: 1px !important;
+    z-index: 1;
+    background: black;
+  }
+}
+.header-component {
+  background-image: url("../../../static/images/dots.png");
+  padding: 35px;
+  background-color: #f3faff;
+  text-align: center;
+  margin-bottom: 40px;
+}


### PR DESCRIPTION
This PR resolves #45 
Created a reusable slick-carousel component to showcase features and other sections for a general website. The carousel is highly customizable with all different properties and null checks enabled. The data which have to be shown on the carousel can be passed as a prop to the component as shown below

![slick-carousel code](https://user-images.githubusercontent.com/62200066/108516343-21367f00-72ec-11eb-8e33-5c66d8fe9ab0.png)

![slick-carousel](https://user-images.githubusercontent.com/62200066/108516361-27c4f680-72ec-11eb-95b9-59144ad5782b.png)
