### PR TITLE
create a reusable sign-up component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {SignupComponent} from './src/components/SignupComponent';

--- a/src/components/SignupComponent/Signup.js
+++ b/src/components/SignupComponent/Signup.js
@@ -1,0 +1,36 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col, Form} from 'react-bootstrap'
+
+const Signup = ({signupMessage, handleSignup}) => {
+  return (
+    <div className="signup-component" style={{ backgroundImage: 'url(./images/dots.png)' }}>
+      <Container>
+        <Row>
+          <Col md={12}>
+            <h1 className="title">Sign up</h1>
+            <p className="main-text">{signupMessage}</p>
+            <Form>
+              <Form.Group controlId="contact-form">
+                <Form.Control type="text" name="name" placeholder="Name" />
+                <Form.Control type="email" name="email" placeholder="E-Mail" />
+                <Form.Control type="text" name="password" placeholder="Password" />
+              </Form.Group>
+              <button type="submit" className="signup-button" onClick={handleSignup}>
+                SIGN UP
+              </button>
+            </Form><br />
+            <p>Already have an account with us? <a href="/login">Login</a></p>
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  )
+}
+
+Signup.propTypes = {
+  signupMessage: PropTypes.string
+}
+
+export default Signup

--- a/src/components/SignupComponent/index.js
+++ b/src/components/SignupComponent/index.js
@@ -1,0 +1,21 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import Signup from './Signup'
+
+export const SignupComponent = ({signupMessage}) => {
+
+  const handleSignup = () => {
+    console.log("Edit this code with what you wish to do with the signup form");
+  }
+
+  return (
+    <div>
+      <Signup handleSignup={handleSignup} />
+    </div>
+  )
+}
+
+SignupComponent.propTypes = {
+  signupMessage: PropTypes.string,
+}

--- a/src/components/SignupComponent/style.sass
+++ b/src/components/SignupComponent/style.sass
@@ -1,0 +1,31 @@
+@import '../../styles/variables.sass'
+
+.signup-component
+  padding: 30px
+  background-color: #fff
+  text-align: center
+  padding-bottom: 120px
+  max-width: 40%
+  .col-md-6
+    @media #{$md-and-less}
+      padding: 0px 20px !important
+    @media #{$xs-and-less}
+      padding: 0px 10px !important
+    padding: 0px 40px !important
+  .title {
+    @media #{$xs-and-less}
+      font-size: 30px
+    padding: 55px 0px 0px 0px
+    font-weight: 400
+  .main-text
+    font-size: 13px
+    line-height: 28px
+  .form-control
+    margin-top: 15px !important
+  .signup-button
+    color: #fff
+    background-color: $primary
+    border: none
+    padding: 8px
+    border-radius: 5px
+    width: 100%


### PR DESCRIPTION
This PR resolves #54 
Created a reusable signup component to which the action to be taken after submitting the form can be passed as a prop. The component can also be customized through stylesheets.

![signup](https://user-images.githubusercontent.com/62200066/108623342-8e6d2000-7464-11eb-9034-66022560a28e.png)
