### PR TITLE
create a reusable login component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {LoginComponent} from './src/components/LoginComponent';

--- a/src/components/LoginComponent/Login.js
+++ b/src/components/LoginComponent/Login.js
@@ -1,0 +1,53 @@
+import React, {useEffect, useState} from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col, Form} from 'react-bootstrap'
+
+const Login = ({loginMessage, handleLogin}) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleEmail = (event) => {
+    setEmail(event.target.value);
+    //console.log(email);
+  }
+
+  const handlePassword = (event) => {
+    setPassword(event.target.value);
+    //console.log(password);
+  }
+
+  return (
+    <div className="signup-component" style={{ backgroundImage: 'url(./images/dots.png)' }}>
+      <Container>
+        <Row>
+          <Col md={12}>
+            <h1 className="title">Log In</h1>
+            <p className="main-text">{loginMessage}</p>
+            <Form>
+              <Form.Group controlId="contact-form">
+                <Form.Control type="email" name="email" placeholder="E-Mail" value={email} onChange={handleEmail} />
+                <Form.Control type="text" name="password" placeholder="Password" value={password} onChange={handlePassword} />
+              </Form.Group>
+              <Form.Group controlId="formBasicCheckbox">
+                <Form.Check type="checkbox" label="Remember Me" />
+              </Form.Group>
+              <button type="submit" className="signup-button" onClick={() => handleLogin(email, password)}>
+                LOG IN
+              </button>
+            </Form>
+            <br />
+            <p>New to us? Register here <a href="/register">Register</a></p>
+
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  )
+}
+
+Login.propTypes = {
+  loginMessage: PropTypes.string
+}
+
+export default Login

--- a/src/components/LoginComponent/index.js
+++ b/src/components/LoginComponent/index.js
@@ -1,0 +1,24 @@
+import React, {useEffect, useState} from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import Login from './Login'
+
+export const LoginComponent = ({loginMessage}) => {
+  const [login, setLogin] = useState(false); // boolean to be set true if validated
+
+  const handleLogin = (email, password) => {
+    //console.log(email);
+    //console.log(password);
+    setLogin(true); // Any other validation needs to go in here
+  }
+
+  return (
+    <div>
+      <Login handleLogin={handleLogin} />
+    </div>
+  )
+}
+
+LoginComponent.propTypes = {
+  loginMessage: PropTypes.string,
+}

--- a/src/components/LoginComponent/style.sass
+++ b/src/components/LoginComponent/style.sass
@@ -1,0 +1,31 @@
+@import '../../styles/variables.sass'
+
+.signup-component
+  padding: 30px
+  background-color: #fff
+  text-align: center
+  padding-bottom: 120px
+  max-width: 40%
+  .col-md-6
+    @media #{$md-and-less}
+      padding: 0px 20px !important
+    @media #{$xs-and-less}
+      padding: 0px 10px !important
+    padding: 0px 40px !important
+  .title
+    @media #{$xs-and-less}
+      font-size: 30px
+    padding: 55px 0px 0px 0px
+    font-weight: 400
+  .main-text
+    font-size: 13px
+    line-height: 28px
+  .form-control
+    margin-top: 15px !important
+  .signup-button
+    color: #fff
+    background-color: $primary
+    border: none
+    padding: 8px
+    border-radius: 5px
+    width: 100%


### PR DESCRIPTION
This PR resolves #55 
Created a reusable login-component with customizable headers and styles passed as props. Email and password have been fetched from the form and sent to a function that would further validate and check them as per wish. Headings and any other message could also be passed as props 

![login](https://user-images.githubusercontent.com/62200066/108680510-f3338380-7513-11eb-9a1c-942eb8dcb391.png)
