### PR TITLE
create a reusable search bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {SearchBarComponent} from './src/components/SearchBarComponent';

--- a/src/components/SearchBarComponent/index.js
+++ b/src/components/SearchBarComponent/index.js
@@ -1,0 +1,57 @@
+import React, {useEffect, useState} from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col} from 'react-bootstrap'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+
+export const SearchBarComponent = ({handleSearch, placeHolder, header}) => {
+  const [searchItem, setSearchItem] = useState("");
+
+  const handleChange = (event) => {
+    setSearchItem(event.target.value);
+  }
+
+  return (
+      <div>
+       {header ? <div>
+                  <div className="header-component"><h1>{header}</h1></div>
+                  <div className="search-box">
+                   <input
+                    className="search-input"
+                    type="text"
+                    placeholder={placeHolder}
+                    value={searchItem}
+                    onChange={handleChange} />
+
+                    <FontAwesomeIcon
+                    onClick={() => handleSearch(searchItem)}
+                    className="icon"
+                    icon={faSearch} />
+
+                  </div>
+                 </div> :
+
+                 <div>
+                  <input
+                   className="search-input"
+                   type="text"
+                   placeholder={placeHolder}
+                   value={searchItem}
+                   onChange={handleChange} />
+
+                   <FontAwesomeIcon
+                   onClick={() => handleSearch(searchItem)}
+                   className="icon"
+                   icon={faSearch} />
+
+                 </div>}
+      </div>
+  )
+}
+
+SearchBarComponent.propTypes = {
+  handleSearch: PropTypes.func,
+  placeHolder: PropTypes.string,
+  header: PropTypes.string
+}

--- a/src/components/SearchBarComponent/style.sass
+++ b/src/components/SearchBarComponent/style.sass
@@ -1,0 +1,26 @@
+@import '../../styles/variables.sass'
+
+.header-component
+  background-image: url("../../../static/images/dots.png")
+  padding: 35px
+  background-color: #f3faff
+  text-align: center
+  margin-bottom: 40px
+.search-input
+  margin: 0 auto
+  float: none
+  width:100%
+  max-width: 300px
+  padding: 5px 10px
+  border: 2px solid green
+.search-input:focus
+  outline: 2px solid green
+.icon
+  color: green
+  font-size: 30px
+  margin-left: 10px
+  padding-top: 10px
+.icon:hover
+  cursor: pointer
+.search-box
+  text-align: center


### PR DESCRIPTION
This PR resolves #22 
As required, Created a reusable search bar component to search any items, projects, contributors or anything else. The component is highly customizable with headers, styles, methods and functions to be passed as props.

![search](https://user-images.githubusercontent.com/62200066/108703758-102a7f80-7531-11eb-9da0-21202c594e60.png)
