### PR TITLE
create a reusable timeline component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {Timeline} from './src/components/TimelineComponent';

--- a/src/components/TimelineComponent/index.js
+++ b/src/components/TimelineComponent/index.js
@@ -1,0 +1,43 @@
+import React from "react"
+import PropTypes from "prop-types"
+import {Container, Row, Col} from 'react-bootstrap'
+import "./style.sass"
+
+export const Timeline = ({data, header}) =>  {
+
+  const TimelineItem = ({ data }) => (
+    <div className="timeline-item">
+        <div className="timeline-item-content">
+            <span className="tag" style={{ background: data.category.color }}>
+                {data.category.tag}
+            </span>
+            <time>{data.date}</time>
+            <p>{data.text}</p>
+            {data.link && (
+                <a
+                    href={data.link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    {data.link.text}
+                </a>
+            )}
+            <span className="circle" />
+        </div>
+    </div>
+);
+
+		return (
+      <div className="timeline-container">
+            {header ? <div className="header-component"><h1 className="title">{header}</h1></div> : null}
+            {data.map((data, idx) => (
+                <TimelineItem data={data} key={idx} />
+            ))}
+      </div>
+		);
+}
+
+Timeline.propTypes = {
+  header: PropTypes.string,
+  data: PropTypes.array
+}

--- a/src/components/TimelineComponent/style.sass
+++ b/src/components/TimelineComponent/style.sass
@@ -1,0 +1,136 @@
+@import '../../styles/variables.sass'
+
+.timeline-container
+    display: flex
+    flex-direction: column
+    position: relative
+    margin: 0
+.timeline-container::after
+    background-color: #e17b77
+    content: ''
+    position: absolute
+    left: calc(50% - 2px)
+    width: 4px
+    height: 100%
+    margin-top: 10rem
+.timeline-item
+    display: flex
+    justify-content: flex-end
+    padding-right: 30px
+    position: relative
+    margin: 10px 0
+    width: 50%
+.timeline-item:nth-child(odd)
+    align-self: flex-end
+    justify-content: flex-start
+    padding-left: 30px
+    padding-right: 0
+.timeline-item-content
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.3)
+    border-radius: 5px
+    background-color: #fff
+    display: flex
+    flex-direction: column
+    align-items: flex-end
+    padding: 15px
+    position: relative
+    width: 400px
+    max-width: 70%
+    text-align: right
+    background-image: url("../../../static/images/dots.png")
+.timeline-item-content::after
+    content: ' '
+    background-color: #fff
+    box-shadow: 1px -1px 1px rgba(0, 0, 0, 0.2)
+    position: absolute
+    right: -7.5px
+    top: calc(50% - 7.5px)
+    transform: rotate(45deg)
+    width: 15px
+    height: 15px
+.timeline-item:nth-child(odd)
+.timeline-item-content
+    text-align: left
+    align-items: flex-start
+.timeline-item:nth-child(odd)
+.timeline-item-content::after
+    right: auto
+    left: -7.5px
+    box-shadow: -1px 1px 1px rgba(0, 0, 0, 0.2)
+.timeline-item-content
+.tag
+    color: #fff
+    font-size: 12px
+    font-weight: bold
+    top: 5px
+    left: 5px
+    letter-spacing: 1px
+    padding: 5px
+    position: absolute
+    text-transform: uppercase
+.timeline-item:nth-child(odd)
+.timeline-item-content
+.tag
+    left: auto
+    right: 5px
+.timeline-item-content
+time
+    color: #777
+    font-size: 12px
+    font-weight: bold
+.timeline-item-content p
+    font-size: 16px
+    line-height: 24px
+    margin: 15px 0
+    max-width: 250px
+.timeline-item-content
+a
+    font-size: 14px
+    font-weight: bold
+.timeline-item-content a::after
+    content: ' ►'
+    font-size: 12px
+.timeline-item-content
+.circle
+    background-color: #fff
+    border: 3px solid #e17b77
+    border-radius: 50%
+    position: absolute
+    top: calc(50% - 10px)
+    right: -40px
+    width: 20px
+    height: 20px
+    z-index: 100
+.timeline-item:nth-child(odd)
+.timeline-item-content
+.circle
+    right: auto
+    left: -40px
+.header-component
+    background-image: url("../../../static/images/dots.png")
+    padding: 35px
+    background-color: #f3faff
+    text-align: center
+    margin-bottom: 40px
+
+@media only screen and (max-width: 1023px)
+    .timeline-item-content
+        max-width: 100%
+@media only screen and (max-width: 767px)
+    .timeline-item-content
+    .timeline-item:nth-child(odd)
+    .timeline-item-content {
+        padding: 15px 10px
+        text-align: center
+        align-items: center
+    .timeline-item-content .tag
+        width: calc(100% - 10px)
+        text-align: center
+    .timeline-item-content
+    time
+        margin-top: 20px
+    .timeline-item-content
+    a
+        text-decoration: underline
+    .timeline-item-content a::after
+        display: none


### PR DESCRIPTION
Created a highly reusable timeline component that can be customized using props and styles.
This PR resolves #62 
In Raw form, it looks like this - 

![timeline-component](https://user-images.githubusercontent.com/62200066/109285433-17120480-7847-11eb-90f7-73da00db68c8.png)

Headers and text and style can be customized using props and data to be passed as - 

![code](https://user-images.githubusercontent.com/62200066/109285581-44f74900-7847-11eb-96d5-a3d58ecb5639.png)

