### PR TITLE
handle empty props to button

### DIFF
--- a/src/components/ButtonWithHeading/index.js
+++ b/src/components/ButtonWithHeading/index.js
@@ -8,11 +8,11 @@ export const ButtonWithHeading = ({ heading, buttonText, onClick = () => {}}) =>
     <div className="button-with-heading-component">
       <Container>
         <Row>
-          <Col> 
-            <h1>{heading}</h1>
-            <button className="button-main" onClick={onClick}>
+          <Col>
+            {heading ? <h1>{heading}</h1> : null}
+            {buttonText ? <button className="button-main" onClick={onClick}>
               {buttonText}
-            </button>
+            </button> : null}
           </Col>
         </Row>
       </Container>


### PR DESCRIPTION
This PR enables checking for valid props to the button component. If 'buttonText' is not passed as a prop, then it will simply not render the button else it will work as desired 

This PR resolves #77 

![Button-correct](https://user-images.githubusercontent.com/62200066/110437751-b5218c80-80db-11eb-95a4-05e4bc90fd58.png)
