### PR TITLE
add previous projects features on idealist

### DIFF
--- a/src/components/GsocIdeaList/index.js
+++ b/src/components/GsocIdeaList/index.js
@@ -6,12 +6,12 @@ import { Collapse } from 'antd';
 
 const { Panel } = Collapse;
 
-export const GsocIdeaList = ({ heading, description, listItems, defaultActiveKeys = []}) => {
+export const GsocIdeaList = ({ heading, description, listItems, previousProjects, defaultActiveKeys = []}) => {
   return (
     <div className="gsoc-idea-list-component">
       <Container>
         <Row>
-          <Col> 
+          <Col>
             {!heading || <h1>{heading}</h1>}
             {!description || <h2>{description}</h2>}
 
@@ -34,14 +34,23 @@ export const GsocIdeaList = ({ heading, description, listItems, defaultActiveKey
 
           </Col>
         </Row>
+        <Row className="button-row">
+           <Col lg={12}><div><h1>Past Years GSoC Projects</h1></div><hr /></Col>
+            {previousProjects ? previousProjects.map(project => (
+             <Col lg={3} md={6} sm={12}>
+              <a href={project.link}><button className="gsoc-button">{project.year}</button></a>
+             </Col>
+            )) : null}
+        </Row>
       </Container>
     </div>
   )
 }
 
 GsocIdeaList.propTypes = {
-  heading: PropTypes.string, 
+  heading: PropTypes.string,
   description: PropTypes.string,
   listItems: PropTypes.array,
+  previousProjects: PropTypes.array,
   defaultActiveKeys: PropTypes.array,
 }

--- a/src/components/GsocIdeaList/style.sass
+++ b/src/components/GsocIdeaList/style.sass
@@ -5,6 +5,22 @@
     font-weight: 500
     font-size: 20px
     background-color: $very-light-grey
+  .button-row
+    text-align: center
+    margin-top: 2rem
+  .gsoc-button
+    background-color: #51ad28
+    border: none
+    border-radius: 4px
+    color: white
+    text-align: center
+    text-decoration: none
+    display: inline-block
+    cursor: pointer
+    padding-left: 1rem
+    padding-right: 1rem
+    padding-top: 0.5rem
+    padding-bottom: 0.5rem
   h1
     margin-top: 15px
     font-size: 22px


### PR DESCRIPTION
This PR fixes #82 

Added the feature to showcase previous year GSoC projects which could simply be passed as props for the same.
The 'previousProjects' prop is an array of objects with a year and link to the projects as its children. It could even be easily customized to serve a specific year.

![past-gsoc](https://user-images.githubusercontent.com/62200066/110783240-2ef97780-828e-11eb-8693-6f6e4e3d619f.png)