### PR TITLE
update the gatsby plugin path

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/src/data`,
+        path: `${__dirname}/src/pages`,
         name: `data`,
       },
     },


### PR DESCRIPTION
This PR resolves #86 
Updated the path in the gatsby-config plugin object to point to correct folder `${__dirname}/src/pages` where index.js resides.
It would make it easier to set the project up locally :)

![correct-gatsby](https://user-images.githubusercontent.com/62200066/111027004-807f3f00-8413-11eb-94f2-bcd41954f5d7.png)
