### PR TITLE
added the reusable alert-component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {AlertComponent} from './src/components/AlertComponent';

--- a/src/components/AlertComponent/index.js
+++ b/src/components/AlertComponent/index.js
@@ -1,0 +1,35 @@
+import React, { useState } from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col, Button, Alert} from 'react-bootstrap'
+
+export const AlertComponent = ({ buttonText, alertText, alertVariant, buttonVariant }) => {
+  const [showAlert, setShowAlert] = useState(false);
+
+  const toggleAlert = () => {
+    const newAlert = (!showAlert)
+    setShowAlert(newAlert);
+  }
+
+  return (
+       <Container className="container">
+          <div>
+          {showAlert ?
+            <Alert variant={alertVariant} onClose={toggleAlert} dismissible>
+               <p>{alertText}</p>
+            </Alert>
+          : null}
+          </div>
+          <div className="alert-button">
+            { buttonText ? <Button variant={buttonVariant} onClick={toggleAlert}>{buttonText}</Button> : null}
+          </div>
+       </Container>
+  )
+}
+
+AlertComponent.propTypes = {
+  buttonText: PropTypes.string,
+  alertText: PropTypes.string,
+  alertVariant: PropTypes.string,
+  buttonVariant: PropTypes.string
+}

--- a/src/components/AlertComponent/style.sass
+++ b/src/components/AlertComponent/style.sass
@@ -1,0 +1,5 @@
+.container
+  text-align: center
+  margin-top: 3rem
+.alert-button
+  margin: 2rem


### PR DESCRIPTION
This PR resolves #91 
Added a reusable alert-component to the generalised website builder which would speed up the process of getting websites up and running easily.
The alert component's color, text and styles can be modified using props like this - 

![alert-props](https://user-images.githubusercontent.com/62200066/111146952-046e2e00-85b0-11eb-9bcc-74490cb0e6d7.png)

The alert component initially - 

![only-button](https://user-images.githubusercontent.com/62200066/111147089-22d42980-85b0-11eb-81b1-d1639b7940c0.png)

When we toggle it - 

![success-alert](https://user-images.githubusercontent.com/62200066/111147123-2962a100-85b0-11eb-8909-a3439f5f1538.png)

![danger-alert](https://user-images.githubusercontent.com/62200066/111147154-2f588200-85b0-11eb-93ff-8eed8544f6b8.png)

