### PR TITLE
fix-no-opportunity-issue

### DIFF
--- a/src/components/JobOpenings/index.js
+++ b/src/components/JobOpenings/index.js
@@ -16,7 +16,7 @@ export const JobOpenings = ({title, openings}) => {
         )}
         {!openings || (
           <Row>
-            {openings.map((opening, i) => (
+            {openings ? openings.map((opening, i) => (
               <Col key={i}>
                 <h5>{opening.title}</h5>
                 <p>{opening.description}</p>
@@ -26,7 +26,7 @@ export const JobOpenings = ({title, openings}) => {
                   ))}
                 </ul>
               </Col>
-            ))}
+            )) : null}
           </Row>
         )}
       </Container>


### PR DESCRIPTION
This PR solves #68 
Currently, when no openings are present, the website renders empty list-items which it should not. So, we need to fix it if no opportunity is available from the props.

The issue is on the main website of https://scorelab.org/ if the 'NAs' are passed knowingly and if this is not a genuine issue, the PR can be closed by maintainers :)

![no-opening](https://user-images.githubusercontent.com/62200066/111300376-064ef480-8677-11eb-81df-f5e3a1c2b938.png)
