### PR TITLE
added modal-component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,23 @@
 // Exporting Webiu Components
-export {ButtonWithHeading} from './src/components/ButtonWithHeading';
-export {Contact} from './src/components/Contact';
-export {DescriptionContainer} from './src/components/DescriptionContainer';
-export {Footer} from './src/components/Footer';
-export {GitterRoomsList} from './src/components/GitterRoomsList';
-export {GuideLines} from './src/components/GuideLines';
-export {Header} from './src/components/Header';
-export {ImageGrid} from './src/components/ImageGrid';
-export {JobOpenings} from './src/components/JobOpenings';
-export {LetterAvatar} from './src/components/LetterAvatar';
-export {LinksList} from './src/components/LinksList';
-export {ListPagination} from './src/components/ListPagination';
-export {MailingListFeed} from './src/components/MailingListFeed';
-export {MediumFeed} from './src/components/MediumFeed';
-export {NavBar} from './src/components/NavBar';
-export {PageNotFound} from './src/components/PageNotFound';
-export {ProjectDetail} from './src/components/ProjectDetail';
-export {ProjectsList} from './src/components/ProjectsList';
-export {PublicationsList} from './src/components/PublicationsList';
-export {Team} from './src/components/Team';
-export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export { ButtonWithHeading } from "./src/components/ButtonWithHeading"
+export { Contact } from "./src/components/Contact"
+export { DescriptionContainer } from "./src/components/DescriptionContainer"
+export { Footer } from "./src/components/Footer"
+export { GitterRoomsList } from "./src/components/GitterRoomsList"
+export { GuideLines } from "./src/components/GuideLines"
+export { Header } from "./src/components/Header"
+export { ImageGrid } from "./src/components/ImageGrid"
+export { JobOpenings } from "./src/components/JobOpenings"
+export { LetterAvatar } from "./src/components/LetterAvatar"
+export { LinksList } from "./src/components/LinksList"
+export { ListPagination } from "./src/components/ListPagination"
+export { MailingListFeed } from "./src/components/MailingListFeed"
+export { MediumFeed } from "./src/components/MediumFeed"
+export { NavBar } from "./src/components/NavBar"
+export { PageNotFound } from "./src/components/PageNotFound"
+export { ProjectDetail } from "./src/components/ProjectDetail"
+export { ProjectsList } from "./src/components/ProjectsList"
+export { PublicationsList } from "./src/components/PublicationsList"
+export { Team } from "./src/components/Team"
+export { GsocIdeaList } from "./src/components/GsocIdeaList"
+export { OnClickModal } from "./src/components/OnClickModal"

--- a/src/components/OnClickModal/index.js
+++ b/src/components/OnClickModal/index.js
@@ -1,0 +1,54 @@
+import React, { useState } from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import { Modal, Button } from "react-bootstrap"
+
+export const OnClickModal = ({
+  buttonText,
+  ModalHeading,
+  ModalBody,
+  FooterBtn1Text,
+  FooterBtn2Text,
+}) => {
+  const [show, setShow] = useState(false)
+
+  const handleClose = () => setShow(false)
+  const handleShow = () => setShow(true)
+
+  return (
+    <div className="Modal">
+      <Button className="main-button btn-success" onClick={handleShow}>
+        {buttonText}
+      </Button>
+
+      <Modal
+        show={show}
+        onHide={handleClose}
+        backdrop="static"
+        keyboard={false}
+      >
+        <Modal.Header>
+          <Modal.Title>{ModalHeading}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{ModalBody}</Modal.Body>
+        <Modal.Footer>
+          <Button className="footer-btn1 btn-success" onClick={handleClose}>
+            {FooterBtn1Text}
+          </Button>
+          <Button className="footer-btn2 btn-success" onClick={handleClose}>
+            {FooterBtn2Text}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  )
+}
+
+OnClickModal.propTypes = {
+  buttonText: PropTypes.string,
+  ModalHeading: PropTypes.string,
+  ModalBody: PropTypes.string,
+  FooterBtn1Text: PropTypes.string,
+  FooterBtn2Text: PropTypes.string,
+  onClick: PropTypes.func,
+}

--- a/src/components/OnClickModal/style.sass
+++ b/src/components/OnClickModal/style.sass
@@ -1,0 +1,23 @@
+@import '../../styles/variables.sass'
+
+.Modal
+    padding: 70px 0px
+    text-align: center
+    @media #{$xs-and-less}
+        min-width: 300px
+    @media #{$tiny-and-less}
+        min-width: 100%
+.main-button
+    color: #fff
+    background-color: $primary
+    align-content: center
+
+.footer-btn1
+    color: #fff
+    background-color: $primary
+    border: none
+
+.footer-btn2
+    color: #fff
+    background-color: $primary
+    border: none


### PR DESCRIPTION
This PR resolves #103 
Added a reusable onClick model-component which is previously not present in website builder.It is highly customizable.
The Button Text,Modal Heading,Modal Body,Modal Buttons can be modified using props like this :- 

![image](https://user-images.githubusercontent.com/53482872/111860474-c08f7600-896d-11eb-9076-23d26b18ba12.png)

The Modal Component Initially:-
![image](https://user-images.githubusercontent.com/53482872/111860531-37c50a00-896e-11eb-9b49-a93dd92f17b8.png)
Modal component when we click on button:-

![image](https://user-images.githubusercontent.com/53482872/111860598-a6a26300-896e-11eb-8453-a658b3351281.png)


