### PR TITLE
updated the avatar to be capitalized

### DIFF
--- a/src/components/LetterAvatar/index.js
+++ b/src/components/LetterAvatar/index.js
@@ -7,7 +7,7 @@ export const LetterAvatar = ({name}) => {
     <div className="letter-avatar-component">
       <div className="letter-avatar-container">
         {!name || (
-          <span className="letter-avatar-text">{name.slice(0,1)}</span>
+          <span className="letter-avatar-text">{name.slice(0,1).toUpperCase()}</span>
         )}
       </div>
     </div>


### PR DESCRIPTION
This PR resolves #109 
This PR fixes the issues of letter-avatar not being capitalized. We use the basic javascript function to always capitalize the first letter of the avatar. For instance, if we pass the same 'yourname' as the prop, We will get capitalized 'Y' in the avatar.

![letter-correct](https://user-images.githubusercontent.com/62200066/112746171-e6022c80-8fca-11eb-8c54-d8600ea1799e.png)
