### PR TITLE
fix the unexpected symbol in 404-component

### DIFF
--- a/src/components/PageNotFound/index.js
+++ b/src/components/PageNotFound/index.js
@@ -10,7 +10,7 @@ export const PageNotFound = ({ image, mainText, subText }) => {
         <img src={withPrefix(image)} alt='404'/>
           <h1>{mainText}</h1>
           <p>
-            {subText} | Return to <Link to='/'>Home</Link> page
+            {subText ? {subText} + '|' : null} Return to <Link to='/'>Home</Link> page
           </p>
       </div>
     </div>


### PR DESCRIPTION
This PR resolves #116 

Modified the current code slightly to handle the empty props and conditionally render the symbol '|' if and only if 'subText' is passed as a prop to the component.

![404-correct](https://user-images.githubusercontent.com/62200066/113291763-1de1da80-9311-11eb-8946-42ab64eef5bd.png)
