### PR TITLE
fix-the-proptypes-issue-in-team-component

### DIFF
--- a/src/components/Team/TeamListItem.js
+++ b/src/components/Team/TeamListItem.js
@@ -17,6 +17,7 @@ TeamMemberItem.propTypes = {
   name: PropTypes.string,
   title: PropTypes.string,
   image: PropTypes.string,
+  horizontal: PropTypes.bool
 }
 
 export default TeamMemberItem

--- a/src/components/Team/index.js
+++ b/src/components/Team/index.js
@@ -14,7 +14,7 @@ export const Team = ({ heads, contributors, researchers, alumni }) => {
             <Row>
               {heads.map((item, i) => (
                 <Col md={6} key={i}>
-                  <TeamListItem 
+                  <TeamListItem
                     name={item.name}
                     title={item.title}
                   />
@@ -25,13 +25,13 @@ export const Team = ({ heads, contributors, researchers, alumni }) => {
         )}
         <br />
 
-        {!researchers || 
+        {!researchers ||
           <div>
             <h3>Researchers</h3>
             <Row>
               {researchers.map((item, i) => (
                 <Col md={4} sm={6} key={i}>
-                  <TeamListItem 
+                  <TeamListItem
                     name={item.name}
                     title={item.title}
                     horizontal
@@ -43,13 +43,13 @@ export const Team = ({ heads, contributors, researchers, alumni }) => {
           </div>
         }
 
-        {!alumni || 
+        {!alumni ||
           <div>
             <h3>Alumni</h3>
             <Row>
               {alumni.map((item, i) => (
                 <Col md={4} sm={6} key={i}>
-                  <TeamListItem 
+                  <TeamListItem
                     name={item.name}
                     title={item.title}
                     horizontal
@@ -67,7 +67,7 @@ export const Team = ({ heads, contributors, researchers, alumni }) => {
             <Row>
               {contributors.map((item, i) => (
                 <Col md={3} sm={4} key={i}>
-                  <TeamListItem 
+                  <TeamListItem
                     name={item.name}
                     title={item.title}
                     horizontal
@@ -87,4 +87,5 @@ Team.propTypes = {
   heads: PropTypes.array,
   researchers: PropTypes.array,
   alumni: PropTypes.array,
+  contributors: PropTypes.array
 }


### PR DESCRIPTION
This PR resolves #120 

Added the correct prop-types of 'contributors' which is an array and 'horizontal' which is a boolean to the Team-Component. Horizontal prop is used to conditionally render the members' list horizontally or vertically