### PR TITLE
create the about us component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {AboutComponent} from './src/components/AboutComponent';

--- a/src/components/AboutComponent/index.js
+++ b/src/components/AboutComponent/index.js
@@ -1,0 +1,43 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import {Container, Row, Col} from 'react-bootstrap'
+import { Link, withPrefix } from "gatsby"
+
+export const AboutComponent = ({header, mainText, subText, buttonText, buttonLink, image, backgroundColor}) => {
+  return (
+    <div>
+    <div className="about-header">{<h1>{header}</h1>}</div>
+    <div style={{ backgroundImage: `url(${withPrefix('/images/dots.png')})` }} className="about-component" >
+      <Container>
+          <Row>
+            <Col md={6} className="left-col">
+              <div className="about-content-section">
+                {mainText ? <h1>
+                  <span className='colored-text'>{mainText.split(' ')[0]}</span>
+                  <span>{mainText.split(' ').map((t, i) => i !== 0 ? ' ' + t : null)}</span>
+                </h1> : null}
+                <p>{subText}</p>
+                {buttonText ? <Link to={buttonLink} className="button">{buttonText}</Link> : null}
+              </div>
+            </Col>
+            <Col md={6} className="right-col">
+              <img className= "about-image" alt="About" src={withPrefix(image)} />
+            </Col>
+          </Row>
+      </Container>
+    </div>
+    </div>
+  )
+}
+
+
+AboutComponent.propTypes = {
+  header: PropTypes.string,
+  mainText: PropTypes.string,
+  subText: PropTypes.string,
+  buttonText: PropTypes.string,
+  buttonLink: PropTypes.string,
+  image: PropTypes.string,
+  backgroundColor: PropTypes.string
+}

--- a/src/components/AboutComponent/style.sass
+++ b/src/components/AboutComponent/style.sass
@@ -1,0 +1,50 @@
+@import '../../styles/variables.sass'
+
+.about-header
+  text-align: center
+  margin: 20px 20px
+.about-component
+  padding: 35px
+  background-color: $light-secondary
+  .small-header-col
+    text-align: center
+    .icon
+      color: $primary
+    h1
+      font-weight: 500
+      margin-bottom: 0px !important
+      font-size: 30px
+  .right-col
+    text-align: center
+    .about-image
+      @media #{$xs-and-less}
+        display: none
+      width: 80%
+  .left-col
+    .about-content-section
+      @media #{$xs-and-less}
+        align-items: center
+        text-align: center
+      display: flex
+      height: 100%
+      flex-direction: column
+      justify-content: center
+      align-items: flex-start
+      h1
+        font-weight: 400
+        padding-top: 15px
+        font-size: 36px
+        .colored-text
+          font-weight: 600
+          color: $primary
+        @media #{$md-and-less}
+          font-size: 30px
+        @media #{$sm-and-less}
+          font-size: 25px
+      p
+        font-size: 14px
+    .button
+      background-color: $secondary
+      color: #fff
+      font-size: 14px
+      padding: 5px 25px


### PR DESCRIPTION
This PR resolves #126 
Created a highly reusable 'about-us' component as per the current theme and keeping it customizable via props passed to it 

![about-us](https://user-images.githubusercontent.com/62200066/113507758-08b3b880-956a-11eb-8120-1ba3b08a8c23.png)

The example of snippet of code rendering the component will be 

![about-code](https://user-images.githubusercontent.com/62200066/113507777-23862d00-956a-11eb-8b14-c52c93bc6be0.png)

All the parameters are passed as variable props and can be altered as per need. Null-checks have also been provided
