### PR TITLE
create an image-avatar component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {ImageAvatar} from './src/components/ImageAvatar';

--- a/src/components/ImageAvatar/index.js
+++ b/src/components/ImageAvatar/index.js
@@ -1,0 +1,17 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+
+export const ImageAvatar = ({ image }) => {
+  return (
+    <div className="image-avatar-component">
+      <div className="image-avatar-container"
+           style={{backgroundImage: `url(${image})`}}>
+      </div>
+    </div>
+  )
+}
+
+ImageAvatar.propTypes = {
+  image: PropTypes.string,
+}

--- a/src/components/ImageAvatar/style.sass
+++ b/src/components/ImageAvatar/style.sass
@@ -1,0 +1,12 @@
+@import '../../styles/variables.sass'
+
+.image-avatar-component
+  margin-right: 10px
+  .image-avatar-container
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 40px
+    height: 40px
+    border-radius: 100%
+    background-color: $primary


### PR DESCRIPTION
This PR resolves #130 
Created a reusable ImageAvatar component that can be customized by passing images and other props to it 
For example - 
![image-avatar](https://user-images.githubusercontent.com/62200066/113675395-ee4c1d00-96d8-11eb-85c0-e321ba085820.png)

![avatar](https://user-images.githubusercontent.com/62200066/113675414-f441fe00-96d8-11eb-9c31-438a63908c52.png)
