### PR TITLE
Create the video player component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
+export {VideoPlayer} from './src/components/VideoPlayer';
 
 

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -1,0 +1,26 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Col } from "react-bootstrap"
+import "./style.sass"
+
+
+export const VideoPlayer = ({ videoSrcURL, title }) => {
+
+  return (
+    <div className="videoplayer-main-component" style={{ backgroundImage: 'url(./images/dots.png)' }}>
+      {title ? <Col md={12}>
+        <h1 className="videoplayer-main-component-title">{title}</h1>
+      </Col> : null}
+      <center>
+        {videoSrcURL ? <div className="embed-responsive embed-responsive-21by9">
+          <iframe className="embed-responsive-item" src={videoSrcURL} allowFullScreen></iframe>
+        </div> : null}
+      </center>
+    </div>
+  )
+}
+
+VideoPlayer.propTypes = {
+  videoSrcURL: PropTypes.string,
+  title: PropTypes.string
+}

--- a/src/components/VideoPlayer/style.sass
+++ b/src/components/VideoPlayer/style.sass
@@ -1,0 +1,15 @@
+@import '../../styles/variables.sass'
+
+.videoplayer-main-component
+  @media #{$xs-and-less}
+    padding: 10px
+  padding: 10px
+  margin: 40px 0px
+  padding: 50px
+  padding-bottom: 70px
+  background-color: $very-light-grey
+  .videoplayer-main-component-title
+    margin: 25px 0px
+    font-weight: 400
+    padding: 0px 0px 25px 0px
+    font-size: 35px


### PR DESCRIPTION
This PR resolves #132 
A reusable component for playing a variety of URLs, including file paths, and embed YouTube, Facebook, Twitch videos. Based on the current theme and making it customizable via props passed to it.

![playerScreenShot](https://user-images.githubusercontent.com/48345668/113742240-085d1e00-9720-11eb-9344-208476be4c87.PNG)

The example of code snippet rendering the component,

![codeScreenShot](https://user-images.githubusercontent.com/48345668/113742402-393d5300-9720-11eb-864e-e210d1625040.PNG)

Props and can be altered as per need.