### PR TITLE
update the image style in description container

### DIFF
--- a/src/components/DescriptionContainer/index.js
+++ b/src/components/DescriptionContainer/index.js
@@ -40,6 +40,7 @@ export const DescriptionContainer = ({title, subTitle, image, mainText, sideComp
 
 DescriptionContainer.propTypes = {
   title: PropTypes.string,
+  subTitle: PropTypes.string,
   image: PropTypes.string,
   mainText: PropTypes.string,
   sideComponent: PropTypes.object

--- a/src/components/DescriptionContainer/style.sass
+++ b/src/components/DescriptionContainer/style.sass
@@ -19,7 +19,7 @@
     padding-bottom: 15px
   .description-container-image
     width: 200px
-    height: 200px
+    height: auto
     @media #{$xs-and-less}
       margin-top: 10px
       width: 160px
@@ -32,5 +32,3 @@
     font-size: 14px
     text-align: justify
     line-height: 28px
-    
-


### PR DESCRIPTION
This PR resolves #134 
Updated the image-styling to be able to resize itself by setting its height to auto. For instance, the example page now looks like - 

![description-correct](https://user-images.githubusercontent.com/62200066/113987647-46675880-986c-11eb-8fae-9105b4e07182.png)

Where the image is not at all stretched and in its original dimension :)