### PR TITLE
update null-check for user-count in gitter-rooms

### DIFF
--- a/src/components/GitterRoomsList/GitterRoomItem.js
+++ b/src/components/GitterRoomsList/GitterRoomItem.js
@@ -9,9 +9,9 @@ const GitterRoomItem = ({name, avatarUrl, roomUrl, userCount}) => {
       <img className="image" alt="Avatar" src={avatarUrl && avatarUrl !== ""  ? avatarUrl : withPrefix('/images/gitterPlaceholder.png')} />
       <div>
         <p className="gitter-room-name">{name}</p>
-        <p className="gitter-room-members">
+        {userCount ? <p className="gitter-room-members">
           {userCount} Members
-        </p>
+        </p> : null}
       </div>
     </div>
   )


### PR DESCRIPTION
This PR resolves #137 
Updated the code to handle empty prop of 'userCount' to GitterListComponent. Now, it will only render the usercount when it has been successfully passed as a prop - 

![issue-resolved](https://user-images.githubusercontent.com/62200066/114311115-1be6fb00-9b0b-11eb-9d2f-aa5e50077c6b.png)
