### PR TITLE
Added the spinner-component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
+export {Spinners} from './src/components/Spinners';
 
 

--- a/src/components/Spinners/index.js
+++ b/src/components/Spinners/index.js
@@ -1,0 +1,21 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Spinner } from "react-bootstrap"
+
+
+export const Spinners = ({ animation, variant, size }) => {
+
+  return (
+    <div>
+      <center>
+        {animation ? <Spinner animation={animation} variant={variant} size={size} /> : <Spinner animation="border" variant={variant} size={size} />}
+      </center>
+    </div>
+  )
+}
+
+Spinners.propTypes = {
+  animation: PropTypes.string,
+  variant: PropTypes.string,
+  size: PropTypes.string
+}


### PR DESCRIPTION
This PR resolves #146 
Added a reusable spinner component to the generalized website builder which can be used to show the loading state in websites.
The spinner component's animation, variant, and size can be modified using props like this -

![SpinnerCode](https://user-images.githubusercontent.com/48345668/114415062-fae6de80-9bcc-11eb-97a9-bc7dd6d5eecd.PNG)

This will result in -

![Loading](https://user-images.githubusercontent.com/48345668/114415300-2ff33100-9bcd-11eb-84b9-ef4f8d483eb0.PNG)
