### PR TITLE
create new profile-card component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,4 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
-
-
+export {CardComponent} from './src/components/CardComponent';

--- a/src/components/CardComponent/index.js
+++ b/src/components/CardComponent/index.js
@@ -1,0 +1,40 @@
+import React from "react"
+import PropTypes from "prop-types"
+import "./style.sass"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLinkedin, faTwitter, faFacebook, faInstagram } from "@fortawesome/free-brands-svg-icons";
+
+export const CardComponent = ({ header, name, description, content, facebook, twitter, instagram, linkedin, image }) => {
+  return (
+    <div>
+    {header ? <div className="header-component"><h1 className="title">{header}</h1></div> : null}
+    <div className="card">
+    <div className="card-img-div">
+    <img src={image} alt="Profile-img" className="card-img" />
+    </div>
+    <h4 className="card-h4">{name}</h4>
+    <p className="card-title">{description}</p>
+    <p className="card-p">{content}</p>
+    <div style={{ margin: "15px 0" }}>
+      <a className="anchor" href={twitter}><FontAwesomeIcon icon={faTwitter} style={{color:'#377293'}} /></a>
+      <a className="anchor" href={linkedin}><FontAwesomeIcon icon={faLinkedin} style={{color:'#377293'}} /></a>
+      <a className="anchor" href={facebook}><FontAwesomeIcon icon={faFacebook} style={{color:'#377293'}} /></a>
+      <a className="anchor" href={instagram}><FontAwesomeIcon icon={faInstagram} style={{color:'#377293'}} /></a>
+    </div>
+    </div>
+    </div>
+  )
+}
+
+
+CardComponent.propTypes = {
+  header: PropTypes.string,
+  name: PropTypes.string,
+  description: PropTypes.string,
+  content: PropTypes.string,
+  facebook: PropTypes.string,
+  twitter: PropTypes.string,
+  instagram: PropTypes.string,
+  linkedin: PropTypes.string,
+  image: PropTypes.string
+}

--- a/src/components/CardComponent/style.sass
+++ b/src/components/CardComponent/style.sass
@@ -1,0 +1,43 @@
+@import '../../styles/variables.sass'
+
+.header-component
+  background-image: url("../../../static/images/dots.png")
+  padding: 35px
+  background-color: #f3faff
+  text-align: center
+  margin-bottom: 40px
+.guests
+	padding: 75px 0
+  background-color: #f6f6f6
+.card
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2)
+  width: 300px
+  margin: auto
+  text-align: center
+  font-family: arial
+  margin-bottom: 2rem
+.card-title
+  color: grey
+  font-size: 18px
+  font-family: Rubik,sans-serif
+.anchor
+  text-decoration: none
+  font-size: 22px
+  color: black
+  padding-right: 1rem
+.anchor:hover
+  opacity: 0.7
+.card-img
+  width: 50%
+  height: auto
+  margin: auto
+  border-radius: 50%
+  margin-top: 2rem
+  box-shadow: 1px 4px 8px 1px rgba(0, 0, 0, 0.2)
+.card-h4
+  margin-top: 1rem
+  color: #183059
+  font-weight: 700
+  font-family: Rubik,sans-serif
+.card-p
+  color: #183059


### PR DESCRIPTION
This PR resolves #155 
Created a new, reusable profile-card component as desired which can be used in showing a person's info or contact card on websites which is quite general these days.

![card](https://user-images.githubusercontent.com/62200066/114841710-c5710980-9df5-11eb-9c7f-f3441e0542d6.png)

The component is completely reusable with all of the names, description, image and links to be passed and altered as props as - 

![card-code](https://user-images.githubusercontent.com/62200066/114841840-e9cce600-9df5-11eb-9540-9e5315339f27.png)
