### PR TITLE
improve the current image-grid component

### DIFF
--- a/src/components/ImageGrid/index.js
+++ b/src/components/ImageGrid/index.js
@@ -4,13 +4,13 @@ import "./style.sass"
 import {Row, Col} from 'react-bootstrap'
 import {withPrefix} from 'gatsby'
 
-export const ImageGrid = ({images}) => {
+export const ImageGrid = ({size, images}) => {
 
   const renderImages = () => {
     return (
       <Row>
         {images.map(i => (
-          <Col md={6} key={i}>
+          <Col md={size === 'medium' ? 6 : 4} key={i}>
             <img alt="Logo" src={withPrefix(i)} />
           </Col>
         ))}


### PR DESCRIPTION
This PR resolves #158 
Made the image-grid component more reusable by adding the option to pass the size of the row as well as a parameter which would conditionally render a different number of images per row as desired as shown below where we render 3 images per row-

![imagegrid-solved](https://user-images.githubusercontent.com/62200066/116360567-afb00b00-a81d-11eb-9e45-d43a3b68ed42.png)

The prop to be passed as - 

![image-grid](https://user-images.githubusercontent.com/62200066/116360616-bd659080-a81d-11eb-877f-1d62ef5538df.png)

