### PR TITLE
Create pricing component

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ export {ProjectsList} from './src/components/ProjectsList';
 export {PublicationsList} from './src/components/PublicationsList';
 export {Team} from './src/components/Team';
 export {GsocIdeaList} from './src/components/GsocIdeaList';
+export {Pricing} from './src/components/Pricing';
 
 

--- a/src/components/Pricing/OnePriceItem.js
+++ b/src/components/Pricing/OnePriceItem.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Col } from 'react-bootstrap'
+import { Link } from "gatsby"
+
+const OnePriceItem = ({ data }) => {
+
+  return (
+    <Col >
+      <div className="pricing-list-item-component" >
+        <div>
+          {data.plan ? <p className="item-title">{data.plan}</p> : null}
+          {data.plan ? <hr /> : null}
+          {data.price ? <h2 className="item-price">
+            ${data.price}
+          </h2> : null}
+          {data.description ? <p>{data.description}</p> : null}
+          {data.items ? <ul>
+            {data.items.map(item => (
+              <li key={item} className="item-features">
+                {item}
+              </li>
+            ))}
+          </ul> : null}
+          <div className="btn-center">
+            {data.buttonLink && data.buttonText ? <Link to={data.buttonLink} className="btn">{data.buttonText}</Link> : null}
+          </div>
+        </div>
+      </div>
+    </Col>
+  )
+}
+
+OnePriceItem.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      plan: PropTypes.string,
+      price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      description: PropTypes.string,
+      items: PropTypes.array,
+      buttonText: PropTypes.string,
+      buttonLink: PropTypes.string
+    }),
+  ),
+}
+
+export default OnePriceItem

--- a/src/components/Pricing/index.js
+++ b/src/components/Pricing/index.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PriceItem from './OnePriceItem'
+import PropTypes from 'prop-types'
+import "./style.sass"
+import { Container, Row, Col } from 'react-bootstrap'
+
+export const Pricing = ({ title, description, plans }) => {
+
+  return (
+    <div className="pricing-list-component">
+      <Container>
+        {!title || (
+          <Row>
+            <Col>
+              <h1 className="title">{title}</h1>
+            </Col>
+          </Row>
+        )}
+        {description ? <p>{description}</p> : null}
+        {plans ? <Row>
+          {plans.map((item, i) => (
+            <PriceItem
+              data={item}
+            />
+          ))}
+        </Row> : null}
+      </Container>
+    </div>
+  )
+}
+Pricing.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  plans: PropTypes.array
+}

--- a/src/components/Pricing/style.sass
+++ b/src/components/Pricing/style.sass
@@ -1,0 +1,51 @@
+@import '../../styles/variables.sass'
+
+.pricing-list-component
+  .title
+    @media #{$xs-and-less}
+      text-align: center
+      font-size: 30px
+    padding: 55px 0px 25px 0px
+    font-weight: 400
+  .pricing-list-item-component
+    min-height: 400px
+    padding: 20px
+    background-color: #fff
+    margin-bottom: 25px
+    border: 1px solid $light-grey
+    border-radius: 5px
+    -webkit-box-shadow: 0px 0px 42px -2px rgba(0,0,0,0.05)
+    -moz-box-shadow: 0px 0px 42px -2px rgba(0,0,0,0.05)
+    box-shadow: 0px 0px 42px -2px rgba(0,0,0,0.05)
+    p
+      margin-bottom: 25px !important
+      font-size: 14px
+      font-weight: 500
+    .item-title
+      margin-bottom: 10px !important
+      font-weight: 600
+      font-size: 25px
+      text-align: center
+    .item-price
+      color: $primary
+      font-weight: 600
+      font-size: 48px
+      text-align: center
+    .item-features
+      font-weight: 400
+      font-size: 16px
+      margin-bottom: 0px !important
+    hr
+      margin: 14px 0px
+    .btn-center
+      text-align: center
+    .btn
+      margin-top: 20px !important
+      background-color: $secondary
+      color: #fff
+      font-size: 14px
+      padding: 5px 25px
+      text-align: center
+      
+
+      


### PR DESCRIPTION
This PR resolves #161 
Created a reusable Pricing component that can be customizable via props passed to it.

![PricingComponentWebSS](https://user-images.githubusercontent.com/48345668/116795757-eb382700-aaf4-11eb-9a04-b1e07c78f9af.png)

The example of snippet of code rendering the component will be,

![PricingComponentSS](https://user-images.githubusercontent.com/48345668/116795794-191d6b80-aaf5-11eb-94f3-16ce9e29ef1d.PNG)

![PricingDataSS](https://user-images.githubusercontent.com/48345668/116795799-220e3d00-aaf5-11eb-8ec5-3976775bedcf.PNG)

All the parameters are passed as variable props and can be altered as per need. Null-checks have also been provided.