### PR TITLE
update the key in guidelines component

### DIFF
--- a/src/components/GuideLines/index.js
+++ b/src/components/GuideLines/index.js
@@ -8,12 +8,12 @@ export const GuideLines = ({ heading, description, guidelines}) => {
     <div className="guide-lines-component" style={{ backgroundImage: 'url(./images/dots.png)' }}>
       <Container>
         <Row>
-          <Col> 
+          <Col>
             <h1>{heading}</h1>
             <h2>{description}</h2>
             <ol>
               {!guidelines || guidelines.map((guideline, i) => (
-                <li key={`${guideline}-${i}`}>{guideline}</li>
+                <li key={i}>{guideline}</li>
               ))}
             </ol>
           </Col>
@@ -24,7 +24,7 @@ export const GuideLines = ({ heading, description, guidelines}) => {
 }
 
 GuideLines.propTypes = {
-  heading: PropTypes.string, 
+  heading: PropTypes.string,
   description: PropTypes.string,
   guidelines: PropTypes.array
 }


### PR DESCRIPTION
This PR resolves #163 
Updated the individual guidelines to have the correct key as their indices in that array. This way the guidelines are bound to their indices.

![correct-1](https://user-images.githubusercontent.com/62200066/117280999-cfc87580-ae80-11eb-8600-6984076fec21.png)

Now when the key is console logged, we see only the indices of the guidelines as keys as shown - 

![solved-issue](https://user-images.githubusercontent.com/62200066/117281112-ecfd4400-ae80-11eb-8997-43583693b69c.png)
