### PR TITLE
Create component markdowns

### DIFF
--- a/src/components/ButtonWithHeading/ButtonWithHeading.md
+++ b/src/components/ButtonWithHeading/ButtonWithHeading.md
@@ -1,0 +1,14 @@
+## Initial Setup
+Hope you have successfully set up the project in your local system and install all dependencies
+
+## About the ButtonWithHeading Component
+This is a resuasble component for one of the most widely used assets in websites - the button. This Component is highly reusable and customizable via props
+
+## How to use the component
+Import the component to `pages/index.js`
+`import {ButtonWithHeading} from "../components/ButtonWithHeading";`
+
+How to handle props to the component
+`<ButtonWithHeading heading="Button With Heading" buttonText="Button" />;`
+
+`heading` and `buttonText` are the two using which you can render customized buttons

--- a/src/components/Contact/Contact.md
+++ b/src/components/Contact/Contact.md
@@ -1,0 +1,14 @@
+## Initial Setup
+Hope you have successfully set up the project in your local system and install all dependencies
+
+## About the Contact Component
+This is a resuasble component for contact and subscribe forms which are very common on modern websites
+
+## How to use the component
+Import the component to `pages/index.js`
+`import {Contact} from "../components/Contact";`
+
+How to handle props to the component
+`<Contact contactMessage="Contact us" subscribeMessage="Subscribe us" />`
+
+The Contact component is a combination of two components namely, `Contact us` and `Subscribe to Email` components where `contactMessage` and `subscribeMessage` are the two props which render different messages to the component heading


### PR DESCRIPTION
This PR resolves #165 
Added the sample component-wise markdown documentation for `Contact` and `ButtonWithHeading` components as shown below - 
The Button Component
![button](https://user-images.githubusercontent.com/62200066/117995541-09a4ea80-b35f-11eb-9550-e3fb9cacd6f2.png)

The Contact Component
![contact](https://user-images.githubusercontent.com/62200066/117995611-16294300-b35f-11eb-8c54-9b4b98218e46.png)

Once I get my request approved, I will soon add the documentation for other components as well