### PR TITLE
Fixed-background image doesn't load after refresh in guidelines component

### DIFF
--- a/src/components/GuideLines/index.js
+++ b/src/components/GuideLines/index.js
@@ -1,20 +1,25 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { withPrefix } from "gatsby"
 import "./style.sass"
-import {Container, Row, Col} from 'react-bootstrap'
+import { Container, Row, Col } from "react-bootstrap"
 
-export const GuideLines = ({ heading, description, guidelines}) => {
+export const GuideLines = ({ heading, description, guidelines }) => {
   return (
-    <div className="guide-lines-component" style={{ backgroundImage: 'url(./images/dots.png)' }}>
+    <div
+      className="guide-lines-component"
+      style={{ backgroundImage: `url(${withPrefix("/images/dots.png")})` }}
+    >
       <Container>
         <Row>
-          <Col> 
+          <Col>
             <h1>{heading}</h1>
             <h2>{description}</h2>
             <ol>
-              {!guidelines || guidelines.map((guideline, i) => (
-                <li key={`${guideline}-${i}`}>{guideline}</li>
-              ))}
+              {!guidelines ||
+                guidelines.map((guideline, i) => (
+                  <li key={`${guideline}-${i}`}>{guideline}</li>
+                ))}
             </ol>
           </Col>
         </Row>
@@ -24,7 +29,7 @@ export const GuideLines = ({ heading, description, guidelines}) => {
 }
 
 GuideLines.propTypes = {
-  heading: PropTypes.string, 
+  heading: PropTypes.string,
   description: PropTypes.string,
-  guidelines: PropTypes.array
+  guidelines: PropTypes.array,
 }


### PR DESCRIPTION
This PR resolves #124 on GSOC2021 page on ScoreLab website.In Guidelines Component the background image dots.png doesn't get load after refresh.As i mentioned the issue in detailed.I have add withPrefix to the path of the image in Guidelines Component which may solve this issue in production.

![113502083-81554d80-9547-11eb-8943-a29f06bb0052](https://user-images.githubusercontent.com/53482872/120886262-a8450400-c60a-11eb-9051-419134d565a9.png)

