### PR TITLE
Expected results data disappear after refresh on scorelab website

### DIFF
--- a/src/components/GsocIdeaList/index.js
+++ b/src/components/GsocIdeaList/index.js
@@ -1,37 +1,42 @@
 import React from "react"
 import PropTypes from "prop-types"
 import "./style.sass"
-import {Container, Row, Col} from 'react-bootstrap'
-import { Collapse } from 'antd';
+import { Container, Row, Col } from "react-bootstrap"
+import { Collapse } from "antd"
 
-const { Panel } = Collapse;
+const { Panel } = Collapse
 
-export const GsocIdeaList = ({ heading, description, listItems, defaultActiveKeys = []}) => {
+export const GsocIdeaList = ({
+  heading,
+  description,
+  listItems,
+  defaultActiveKeys = [],
+}) => {
   return (
     <div className="gsoc-idea-list-component">
       <Container>
         <Row>
-          <Col> 
+          <Col>
             {!heading || <h1>{heading}</h1>}
             {!description || <h2>{description}</h2>}
 
             <Collapse defaultActiveKey={defaultActiveKeys}>
-              {!listItems || listItems.map((item, i) => (
-                <Panel header={item.title} key={`${i}`}>
-                  <h4>Description</h4>
-                  <p dangerouslySetInnerHTML={{ __html: item.description}}></p>
-                  <h4>Expected Results</h4>
-                  <p dangerouslySetInnerHTML={{ __html: item.expectedresults}}></p>
-                  <h4>Required Knowledge</h4>
-                  <p>{item.requiredknowledge}</p>
-                  <h4>Possible Mentors</h4>
-                  <p>{item.possiblementors}</p>
-                  <h4>Github Url</h4>
-                  <a href={item.githuburl}>{item.githuburl}</a>
-                </Panel>
-              ))}
+              {!listItems ||
+                listItems.map((item, i) => (
+                  <Panel header={item.title} key={`${i}`}>
+                    <h4>Description</h4>
+                    <p>{item.description}</p>
+                    <h4>Expected Results</h4>
+                    <p>{item.expectedresults}</p>
+                    <h4>Required Knowledge</h4>
+                    <p>{item.requiredknowledge}</p>
+                    <h4>Possible Mentors</h4>
+                    <p>{item.possiblementors}</p>
+                    <h4>Github Url</h4>
+                    <a href={item.githuburl}>{item.githuburl}</a>
+                  </Panel>
+                ))}
             </Collapse>
-
           </Col>
         </Row>
       </Container>
@@ -40,7 +45,7 @@ export const GsocIdeaList = ({ heading, description, listItems, defaultActiveKey
 }
 
 GsocIdeaList.propTypes = {
-  heading: PropTypes.string, 
+  heading: PropTypes.string,
   description: PropTypes.string,
   listItems: PropTypes.array,
   defaultActiveKeys: PropTypes.array,


### PR DESCRIPTION
The issue is on scorelab website Gsoc2021 page in idealist the expected results data disappear after refresh which is because the dangerouslySetInnerHTML on p tag.
I have removed the dangerouslySetInnerHTML which was on p tag in GsocIdealist component which may solve the issue in production.
I google the issue for sometime and found that this is due to the nested p tag.I am leaving a reference link of similar react and gatsby issue.
Reference link:-
[React Issue](https://github.com/facebook/react/issues/5479)
[Gatsby Issue](https://github.com/gatsbyjs/gatsby/issues/11108)

