### PR TITLE
Expected results data disappear after refresh on scorelab website

### DIFF
--- a/src/components/GsocIdeaList/index.js
+++ b/src/components/GsocIdeaList/index.js
@@ -1,54 +1,75 @@
 import React from "react"
 import PropTypes from "prop-types"
 import "./style.sass"
-import {Container, Row, Col} from 'react-bootstrap'
-import { Collapse } from 'antd';
+import { Container, Row, Col } from "react-bootstrap"
+import { Collapse } from "antd"
 
-const { Panel } = Collapse;
+const { Panel } = Collapse
 
-export const GsocIdeaList = ({ heading, description, listItems, previousProjects, defaultActiveKeys = []}) => {
+export const GsocIdeaList = ({
+  heading,
+  description,
+  listItems,
+  previousProjects,
+  defaultActiveKeys = [],
+}) => {
   return (
     <div className="gsoc-idea-list-component">
       <Container>
         <Row>
-          <Col> 
+          <Col>
             {!heading || <h1>{heading}</h1>}
             {!description || <h2>{description}</h2>}
 
             <Collapse defaultActiveKey={defaultActiveKeys}>
-              {!listItems || listItems.map((item, i) => (
-                <Panel header={item.title} key={`${i}`}>
-                  <h4>Description</h4>
-                  <p dangerouslySetInnerHTML={{ __html: item.description}}></p>
-                  <h4>Expected Results</h4>
-                  <p dangerouslySetInnerHTML={{ __html: item.expectedresults}}></p>
-                  <h4>Required Knowledge</h4>
-                  <p>{item.requiredknowledge}</p>
-                  <h4>Possible Mentors</h4>
-                  <p>{item.possiblementors}</p>
-                  <h4>Github Url</h4>
-                  <a href={item.githuburl}>{item.githuburl}</a>
-                </Panel>
-              ))}
+              {!listItems ||
+                listItems.map((item, i) => (
+                  <Panel header={item.title} key={`${i}`}>
+                    <h4>Description</h4>
+                    <p
+                      dangerouslySetInnerHTML={{ __html: item.description }}
+                    ></p>
+                    <h4>Expected Results</h4>
+                    <div
+                      dangerouslySetInnerHTML={{ __html: item.expectedresults }}
+                    ></div>
+                    <h4>Required Knowledge</h4>
+                    <p>{item.requiredknowledge}</p>
+                    <h4>Possible Mentors</h4>
+                    <p>{item.possiblementors}</p>
+                    <h4>Github Url</h4>
+                    <a href={item.githuburl}>{item.githuburl}</a>
+                  </Panel>
+                ))}
             </Collapse>
-
           </Col>
         </Row>
-        {previousProjects ? <Row className="button-row">
-           <Col lg={12}><div><h1>Past Years GSoC Projects</h1></div><hr /></Col>
-            {previousProjects ? previousProjects.map(project => (
-             <Col lg={3} md={6} sm={12}>
-              <a href={project.link} target="_blank" rel="noreferrer"><button className="gsoc-button">{project.year}</button></a>
-             </Col>
-            )) : null}
-        </Row> : null}
+        {previousProjects ? (
+          <Row className="button-row">
+            <Col lg={12}>
+              <div>
+                <h1>Past Years GSoC Projects</h1>
+              </div>
+              <hr />
+            </Col>
+            {previousProjects
+              ? previousProjects.map(project => (
+                  <Col lg={3} md={6} sm={12}>
+                    <a href={project.link} target="_blank" rel="noreferrer">
+                      <button className="gsoc-button">{project.year}</button>
+                    </a>
+                  </Col>
+                ))
+              : null}
+          </Row>
+        ) : null}
       </Container>
     </div>
   )
 }
 
 GsocIdeaList.propTypes = {
-  heading: PropTypes.string, 
+  heading: PropTypes.string,
   description: PropTypes.string,
   listItems: PropTypes.array,
   defaultActiveKeys: PropTypes.array,


### PR DESCRIPTION
This resolves #174 
The issue is on scorelab website Gsoc2021 page in idealist the expected results data disappear after refresh which is because the dangerouslySetInnerHTML on p tag.
I have added div tag instead of p tag which may solve this issue in production.
I google the issue for sometime and found that this is due to the nested p tag.I am leaving a reference link of similar react and gatsby issue.
Reference link:-
[React Issue](https://github.com/facebook/react/issues/5479)
[Gatsby Issue](https://github.com/gatsbyjs/gatsby/issues/11108)

