### PR TITLE
home screen distortion fixed

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,10 +2,18 @@ import React from "react"
 
 const ExamplePage = () => {
   return (
-    <div>
-      <div style={{position: "absolute", top: "40%", left: "20%"}}>
-        <h3>Start editing the 'pages/index.js' file to import and show component</h3>
-      </div>
+    <div
+      style={{
+        position: "absolute",
+        textAlign: "center",
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+      }}
+    >
+      <h3 style={{ lineHeight: "45px" }}>
+        Start editing the 'pages/index.js' file to import and show component
+      </h3>
     </div>
   )
 }


### PR DESCRIPTION
This PR resolves #186.

I have fixed the home screen distortion issue by adding proper css.And now the text is also responsive on mobile devices.

Screenshots: 
OS: macOS
Browser: chrome
<img width="1436" alt="Screenshot 2021-10-07 at 2 13 49 PM" src="https://user-images.githubusercontent.com/53482872/136354867-72c1f3fe-a863-4fe6-911a-b9eec1189023.png">

Device: iphone 6
OS: iOS
Browser: Chrome
<img width="328" alt="Screenshot 2021-10-07 at 2 26 08 PM" src="https://user-images.githubusercontent.com/53482872/136354934-5fabea39-fa47-4a45-9462-29f8630bce22.png">