### PR TITLE
Fixed:- Can't resolve './antd/dist/antd.css'

### DIFF
--- a/src/components/GsocIdeaList/style.sass
+++ b/src/components/GsocIdeaList/style.sass
@@ -1,5 +1,5 @@
 @import '../../styles/variables.sass'
-@import 'antd/dist/antd.css'
+@import '~antd/dist/antd.css'
 
 .gsoc-idea-list-component
   .ant-collapse-header


### PR DESCRIPTION
<!--- Provide a suitable title for the changes you have done -->
This PR resolves #202 

## Description
There was typo in a sass file of GsocIdeaList component.Because of that code was not compiling.The typo is now fixed by this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

